### PR TITLE
Add Semantic View as Materialization

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20250821-155606.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250821-155606.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add semantic View as materialization
+time: 2025-08-21T15:56:06.076414-07:00
+custom:
+    Author: sfc-gh-yutliu
+    Issue: "1260"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -44,6 +44,7 @@ class SnowflakeRelation(BaseRelation):
             {
                 SnowflakeRelationType.Table,  # type: ignore
                 SnowflakeRelationType.View,  # type: ignore
+                SnowflakeRelationType.SemanticView,
             }
         )
     )
@@ -54,6 +55,7 @@ class SnowflakeRelation(BaseRelation):
                 SnowflakeRelationType.DynamicTable,  # type: ignore
                 SnowflakeRelationType.Table,  # type: ignore
                 SnowflakeRelationType.View,  # type: ignore
+                SnowflakeRelationType.SemanticView,
             }
         )
     )
@@ -65,6 +67,10 @@ class SnowflakeRelation(BaseRelation):
     @property
     def is_iceberg_format(self) -> bool:
         return self.table_format == TableFormat.ICEBERG
+
+    @property
+    def is_semantic_view(self) -> bool:
+        return self.type == SnowflakeRelationType.SemanticView
 
     @classproperty
     def DynamicTable(cls) -> str:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -44,7 +44,7 @@ class SnowflakeRelation(BaseRelation):
             {
                 SnowflakeRelationType.Table,  # type: ignore
                 SnowflakeRelationType.View,  # type: ignore
-                SnowflakeRelationType.SemanticView,
+                SnowflakeRelationType.SemanticView,  # type: ignore
             }
         )
     )
@@ -55,7 +55,7 @@ class SnowflakeRelation(BaseRelation):
                 SnowflakeRelationType.DynamicTable,  # type: ignore
                 SnowflakeRelationType.Table,  # type: ignore
                 SnowflakeRelationType.View,  # type: ignore
-                SnowflakeRelationType.SemanticView,
+                SnowflakeRelationType.SemanticView,  # type: ignore
             }
         )
     )

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/policies.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/policies.py
@@ -10,6 +10,7 @@ class SnowflakeRelationType(StrEnum):
     CTE = "cte"
     External = "external"
     DynamicTable = "dynamic_table"
+    SemanticView = "semantic_view"
 
 
 class SnowflakeIncludePolicy(Policy):

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/adapters.sql
@@ -205,6 +205,8 @@
 {% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
     {%- if relation.is_dynamic_table -%}
         {%- set relation_type = 'dynamic table' -%}
+    {% elif relation.is_semantic_view -%}
+        {%- set relation_type = 'semantic view' -%}
     {%- else -%}
         {%- set relation_type = relation.type -%}
     {%- endif -%}
@@ -216,6 +218,8 @@
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
     {% if relation.is_dynamic_table -%}
         {% set relation_type = "table" %}
+    {% elif relation.is_semantic_view -%}
+        {%- set relation_type = 'semantic view' -%}
     {% else -%}
         {% set relation_type = relation.type %}
     {% endif %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/semantic_view.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/semantic_view.sql
@@ -1,0 +1,15 @@
+{% materialization semantic_view, adapter='snowflake' -%}
+
+    {% set original_query_tag = set_query_tag() %}
+    {% set to_return = snowflake__create_or_replace_semantic_view() %}
+
+    {% set target_relation = this.incorporate(type='semantic_view') %}
+
+    -- Requires COMMENT ON SEMANTIC VIEW support
+    -- {% do persist_docs(target_relation, model, for_columns=false) %}
+
+    {% do unset_query_tag(original_query_tag) %}
+
+    {% do return(to_return) %}
+
+{%- endmaterialization %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/semantic_view.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/semantic_view.sql
@@ -5,8 +5,8 @@
 
     {% set target_relation = this.incorporate(type='semantic_view') %}
 
-    -- Requires COMMENT ON SEMANTIC VIEW support
-    -- {% do persist_docs(target_relation, model, for_columns=false) %}
+    -- COMMENT ON SEMANTIC VIEW support
+    {% do persist_docs(target_relation, model, for_columns=false) %}
 
     {% do unset_query_tag(original_query_tag) %}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/create.sql
@@ -3,6 +3,9 @@
     {% if relation.is_dynamic_table %}
         {{ snowflake__get_create_dynamic_table_as_sql(relation, sql) }}
 
+    {% elif relation.is_semantic_view %}
+        {{ snowflake__get_create_semantic_view_sql(relation, sql) }}
+
     {% else %}
         {{ default__get_create_sql(relation, sql) }}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
@@ -1,0 +1,46 @@
+{% macro snowflake__get_create_semantic_view_sql(relation, sql) -%}
+{#-
+--  Produce DDL that creates a semantic view
+--
+--  Args:
+--  - relation: Union[SnowflakeRelation, str]
+--      - SnowflakeRelation - required for relation.render()
+--      - str - is already the rendered relation name
+--  - sql: str - the code defining the model
+--  Returns:
+--      A valid DDL statement which will result in a new semantic view.
+-#}
+
+  create semantic view {{ relation }}
+  {{ sql }}
+
+{%- endmacro %}
+
+
+{% macro snowflake__create_or_replace_semantic_view() %}
+  {%- set identifier = model['alias'] -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_semantic_view) -%}
+
+  {%- set target_relation = api.Relation.create(
+      identifier=identifier, schema=schema, database=database,
+      type='semantic_view') -%}
+  {% set grant_config = config.get('grants') %}
+
+  {{ run_hooks(pre_hooks) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ snowflake__get_create_semantic_view_sql(target_relation, sql) }}
+  {%- endcall %}
+
+  -- TODO: Properly handle hierarchy of specification
+  -- {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
+  -- {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {{ run_hooks(post_hooks) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
@@ -22,11 +22,23 @@
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set exists_as_view = (old_relation is not none and old_relation.is_semantic_view) -%}
+  {%- set copy_grants = config.get('copy_grants', default=false) -%}
 
   {%- set target_relation = api.Relation.create(
       identifier=identifier, schema=schema, database=database,
       type='semantic_view') -%}
   {% set grant_config = config.get('grants') %}
+
+  {%- if copy_grants -%}
+    {#- Normalize SQL and append COPY GRANTS if not already present (case-insensitive) -#}
+    {%- set _sql_norm = sql | trim -%}
+    {%- set _sql_norm = _sql_norm[:-1] if _sql_norm[-1:] == ';' else _sql_norm -%}
+    {%- set _sql_norm = _sql_norm | trim -%}
+    {%- set _ends = (_sql_norm | lower)[-11:] -%}
+    {%- if _ends != 'copy grants' -%}
+      {%- set sql = sql ~ '\nCOPY GRANTS' -%}
+    {%- endif -%}
+  {%- endif -%}
 
   {{ run_hooks(pre_hooks) }}
 
@@ -34,10 +46,6 @@
   {% call statement('main') -%}
     {{ snowflake__get_create_semantic_view_sql(target_relation, sql) }}
   {%- endcall %}
-
-  -- TODO: Properly handle hierarchy of specification
-  -- {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
-  -- {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {{ run_hooks(post_hooks) }}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
@@ -11,7 +11,7 @@
 --      A valid DDL statement which will result in a new semantic view.
 -#}
 
-  create semantic view {{ relation }}
+  create or replace semantic view {{ relation }}
   {{ sql }}
 
 {%- endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/drop.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/drop.sql
@@ -1,0 +1,3 @@
+{% macro snowflake__get_drop_semantic_view_sql(relation) %}
+    drop semantic view if exists {{ relation }}
+{% endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/rename.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/rename.sql
@@ -1,0 +1,11 @@
+{%- macro snowflake__get_semantic_view_rename_sql(relation, new_name) -%}
+    /*
+    Rename or move a semantic view to the new name.
+
+    Args:
+        relation: SnowflakeRelation - relation to be renamed
+        new_name: Union[str, SnowflakeRelation] - new name for `relation`
+    Returns: templated string
+    */
+    alter semantic view if exists {{ relation }} rename to {{ new_name }}
+{%- endmacro -%}

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -44,6 +44,14 @@ METRICS(t1.total_rows AS SUM(t1.value))
 COMMENT='test semantic view yaml copy grants'
 """
 
+_MODEL__SEMANTIC_VIEW_WITH_EXTENSION_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
+with extension (CA = '{"verified_queries":[{"name":"hi", "question": "hello"}]')
+"""
+
 _SCHEMA_YML = """
 version: 2
 
@@ -81,6 +89,7 @@ class TestSemanticViewBasic:
             "my_semantic_view_without_copy.sql": _MODEL__SEMANTIC_VIEW_WITHOUT_COPY_SQL,
             "table_refer_to_semantic_view.sql": _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL,
             "table_refer_to_raw_semantic_view.sql": _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL,
+            "table_with_ca_extension.sql": _MODEL__SEMANTIC_VIEW_WITH_EXTENSION_SQL,
             "sources.yml": _SOURCES_YML,
             "schema.yml": _SCHEMA_YML,
         }
@@ -236,3 +245,25 @@ class TestSemanticViewBasic:
             in logs_without.lower()
         )
         assert "copy grants" not in logs_without_sql_or_yaml.lower()
+
+    def test_semantic_view_with_ca_extension(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.table_with_ca_extension"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(
+            ["--debug", "run", "--select", "table_with_ca_extension.sql"]
+        )
+        assert f"create or replace semantic view {qualified}" in logs.lower()
+
+        desc_semantic_view_sql = f"describe semantic view {qualified}"
+        desc_remantic_view_res = project.run_sql(desc_semantic_view_sql, fetch="all")
+        for row in desc_remantic_view_res:
+            if row[0].lower() == "extension":
+                assert row[1].lower() == "ca"
+                assert row[4].lower() == '{"verified_queries":[{"name":"hi", "question": "hello"}]'
+                break
+        else:
+            assert False, "Extension not found"

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -23,6 +23,20 @@ _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL = """
 select * from semantic_view({{ ref('my_semantic_view') }} metrics total_rows)
 """
 
+_MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL = """
+{{ config(materialized='table') }}
+select * from semantic_view({{ source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
+"""
+
+_SOURCES_YML = """
+version: 2
+sources:
+  - name: seed_sources
+    schema: "{{ target.schema }}"
+    tables:
+      - name: raw_semantic_view
+"""
+
 
 class TestSemanticViewBasic:
     @pytest.fixture(scope="class", autouse=True)
@@ -35,12 +49,26 @@ class TestSemanticViewBasic:
             "base_table.sql": _MODEL__BASE_TABLE_SQL,
             "my_semantic_view.sql": _MODEL__SEMANTIC_VIEW_SQL,
             "table_refer_to_semantic_view.sql": _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL,
+            "table_refer_to_raw_semantic_view.sql": _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL,
+            "sources.yml": _SOURCES_YML,
         }
 
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, project):
-        run_dbt(["seed"])  # load seed for base table
-        run_dbt(["run", "--select", "base_table"])  # create the base table
+        run_dbt(["seed"])
+        run_dbt(["run", "--select", "base_table"])
+
+        database = project.database
+        schema = project.test_schema
+
+        project.run_sql(
+            f"""
+            create or replace semantic view raw_semantic_view
+            tables(t1 as {database}.{schema}.base_table)
+            dimensions(t1.count as value)
+            metrics(t1.total_rows as sum(t1.value))
+        """
+        )
 
     def test_create_semantic_view(self, project):
         database = project.database
@@ -75,5 +103,30 @@ class TestSemanticViewBasic:
         table_select_star_sql = f"select * from {database}.{schema}.TABLE_REFER_TO_SEMANTIC_VIEW"
         table_select_result = project.run_sql(table_select_star_sql, fetch="all")
         semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.MY_SEMANTIC_VIEW metrics total_rows);"
+        semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
+        assert table_select_result[0][0] == semantic_view_select_result[0][0]
+
+    def test_table_refer_to_raw_semantic_view(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.table_refer_to_raw_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(
+            [
+                "--debug",
+                "run",
+                "--select",
+                "+table_refer_to_raw_semantic_view.sql",
+            ]
+        )
+        assert f"create or replace transient table {qualified}" in logs.lower()
+        # verify the select-star result of the table which refer to the semantic view and the semantic view are the same
+        table_select_star_sql = (
+            f"select * from {database}.{schema}.table_refer_to_raw_semantic_view"
+        )
+        table_select_result = project.run_sql(table_select_star_sql, fetch="all")
+        semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.raw_semantic_view metrics total_rows);"
         semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
         assert table_select_result[0][0] == semantic_view_select_result[0][0]

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -1,0 +1,52 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+
+_SEED__DATA = """id,value\n1,100\n2,200\n3,300\n"""
+
+_MODEL__BASE_TABLE_SQL = """
+{{ config(materialized='table') }}
+select * from {{ ref('my_seed') }}
+"""
+
+_MODEL__SEMANTIC_VIEW_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }})
+METRICS(t1.total_rows AS COUNT(*))
+COMMENT='test semantic view'
+COPY GRANTS
+"""
+
+
+class TestSemanticViewBasic:
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": _SEED__DATA}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        return {
+            "base_table.sql": _MODEL__BASE_TABLE_SQL,
+            "my_semantic_view.sql": _MODEL__SEMANTIC_VIEW_SQL,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])  # load seed for base table
+        run_dbt(["run", "--select", "base_table"])  # create the base table
+
+    def test_create_semantic_view(self, project):
+        qualified = f"{project.database}.{project.test_schema}.my_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(["--debug", "run", "--select", "my_semantic_view.sql"])
+        assert f"create semantic view {qualified}" in logs.lower()
+
+        # Verify existence via SHOW SEMANTIC VIEWS (preferred for semantic views)
+        exists_sql = (
+            f"show semantic views like 'MY_SEMANTIC_VIEW' in schema "
+            f"{project.database}.{project.test_schema}"
+        )
+        rows = project.run_sql(exists_sql, fetch="all")
+        assert rows and len(rows) >= 1, "semantic view not found via SHOW SEMANTIC VIEWS"

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -11,9 +11,9 @@ select * from {{ ref('my_seed') }}
 
 _MODEL__SEMANTIC_VIEW_SQL = """
 {{ config(materialized='semantic_view') }}
-TABLES(t1 AS {{ ref('base_table') }})
-DIMENSIONS(t1.count as value)
-METRICS(t1.total_rows AS SUM(t1.value))
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
 COMMENT='test semantic view'
 COPY GRANTS
 """
@@ -43,6 +43,7 @@ sources:
     schema: "{{ target.schema }}"
     tables:
       - name: raw_semantic_view
+      - name: base_table2
 """
 
 
@@ -82,6 +83,14 @@ class TestSemanticViewBasic:
         database = project.database
         schema = project.test_schema
 
+        # Create a physical source table with different values than base_table
+        project.run_sql(
+            f"""
+            create or replace table {database}.{schema}.base_table2 as
+            select id, value + 1000 as value from {database}.{schema}.base_table
+        """
+        )
+
         project.run_sql(
             f"""
             create or replace semantic view raw_semantic_view
@@ -107,6 +116,13 @@ class TestSemanticViewBasic:
         )
         rows = project.run_sql(exists_sql, fetch="all")
         assert rows and len(rows) >= 1, "semantic view not found via SHOW SEMANTIC VIEWS"
+
+        # verify the select-star result of the table which refer to the semantic view and the semantic view are the same
+        table_select_star_sql = f"select sum(value) from {database}.{schema}.BASE_TABLE"
+        table_select_result = project.run_sql(table_select_star_sql, fetch="all")
+        semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.MY_SEMANTIC_VIEW metrics total_rows);"
+        semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
+        assert table_select_result[0][0] == semantic_view_select_result[0][0]
 
     def test_table_refer_to_semantic_view(self, project):
         database = project.database

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -15,7 +15,6 @@ TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_tabl
 DIMENSIONS(t1.count as value, t2.volume as value)
 METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
 COMMENT='test semantic view'
-COPY GRANTS
 """
 
 _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL = """
@@ -28,12 +27,33 @@ _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL = """
 select * from semantic_view({{ source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
 """
 
+_MODEL__SEMANTIC_VIEW_WITH_COPY_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.value))
+COMMENT='test semantic view explicit copy grants'
+COPY GRANTS
+"""
+
+_MODEL__SEMANTIC_VIEW_WITHOUT_COPY_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.value))
+COMMENT='test semantic view yaml copy grants'
+"""
+
 _SCHEMA_YML = """
 version: 2
 
 models:
   - name: my_semantic_view
     description: "Semantic view description for persist_docs"
+  - name: my_semantic_view_without_copy
+    config:
+      copy_grants: true
+  - name: my_semantic_view_with_copy
 """
 
 _SOURCES_YML = """
@@ -57,6 +77,8 @@ class TestSemanticViewBasic:
         return {
             "base_table.sql": _MODEL__BASE_TABLE_SQL,
             "my_semantic_view.sql": _MODEL__SEMANTIC_VIEW_SQL,
+            "my_semantic_view_with_copy.sql": _MODEL__SEMANTIC_VIEW_WITH_COPY_SQL,
+            "my_semantic_view_without_copy.sql": _MODEL__SEMANTIC_VIEW_WITHOUT_COPY_SQL,
             "table_refer_to_semantic_view.sql": _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL,
             "table_refer_to_raw_semantic_view.sql": _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL,
             "sources.yml": _SOURCES_YML,
@@ -183,3 +205,34 @@ class TestSemanticViewBasic:
         )
         rows = project.run_sql(exists_sql, fetch="all")
         assert "semantic view description for persist_docs" in rows[0][4].lower()
+
+    def test_semantic_view_copy_grants_logic(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        # Case 1: SQL already ends with COPY GRANTS -> should not rely on yaml, appears in DDL
+        qualified_with = f"{database}.{schema}.my_semantic_view_with_copy"
+        _, logs_with = run_dbt_and_capture(
+            ["--debug", "run", "--select", "my_semantic_view_with_copy.sql"]
+        )
+        assert f"create or replace semantic view {qualified_with}" in logs_with.lower()
+        assert "copy grants" in logs_with.lower()
+
+        # Case 2: SQL does not end with COPY GRANTS but YAML sets copy_grants: true -> appended
+        qualified_without = f"{database}.{schema}.my_semantic_view_without_copy"
+        _, logs_without = run_dbt_and_capture(
+            ["--debug", "run", "--select", "my_semantic_view_without_copy.sql"]
+        )
+        assert f"create or replace semantic view {qualified_without}" in logs_without.lower()
+        assert "copy grants" in logs_without.lower()
+
+        # Case 3: SQL does not end with COPY GRANTS and YAML does not set copy_grants: true -> no copy grants
+        qualified_without_sql_or_yaml = f"{database}.{schema}.my_semantic_view"
+        _, logs_without_sql_or_yaml = run_dbt_and_capture(
+            ["--debug", "run", "--select", "my_semantic_view.sql"]
+        )
+        assert (
+            f"create or replace semantic view {qualified_without_sql_or_yaml}"
+            in logs_without.lower()
+        )
+        assert "copy grants" not in logs_without_sql_or_yaml.lower()

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt.tests.util import run_dbt, run_dbt_and_capture
 
-
 _SEED__DATA = """id,value\n1,100\n2,200\n3,300\n"""
 
 _MODEL__BASE_TABLE_SQL = """
@@ -19,6 +18,11 @@ COMMENT='test semantic view'
 COPY GRANTS
 """
 
+_MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL = """
+{{ config(materialized='table') }}
+select * from semantic_view({{ ref('my_semantic_view') }} metrics total_rows)
+"""
+
 
 class TestSemanticViewBasic:
     @pytest.fixture(scope="class", autouse=True)
@@ -30,6 +34,7 @@ class TestSemanticViewBasic:
         return {
             "base_table.sql": _MODEL__BASE_TABLE_SQL,
             "my_semantic_view.sql": _MODEL__SEMANTIC_VIEW_SQL,
+            "table_refer_to_semantic_view.sql": _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL,
         }
 
     @pytest.fixture(scope="class", autouse=True)
@@ -53,3 +58,22 @@ class TestSemanticViewBasic:
         )
         rows = project.run_sql(exists_sql, fetch="all")
         assert rows and len(rows) >= 1, "semantic view not found via SHOW SEMANTIC VIEWS"
+
+    def test_table_refer_to_semantic_view(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.table_refer_to_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(
+            ["--debug", "run", "--select", "+table_refer_to_semantic_view.sql"]
+        )
+        assert f"create or replace transient table {qualified}" in logs.lower()
+
+        # verify the select-star result of the table which refer to the semantic view and the semantic view are the same
+        table_select_star_sql = f"select * from {database}.{schema}.TABLE_REFER_TO_SEMANTIC_VIEW"
+        table_select_result = project.run_sql(table_select_star_sql, fetch="all")
+        semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.MY_SEMANTIC_VIEW metrics total_rows);"
+        semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
+        assert table_select_result[0][0] == semantic_view_select_result[0][0]

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -13,7 +13,8 @@ select * from {{ ref('my_seed') }}
 _MODEL__SEMANTIC_VIEW_SQL = """
 {{ config(materialized='semantic_view') }}
 TABLES(t1 AS {{ ref('base_table') }})
-METRICS(t1.total_rows AS COUNT(*))
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.value))
 COMMENT='test semantic view'
 COPY GRANTS
 """
@@ -37,16 +38,18 @@ class TestSemanticViewBasic:
         run_dbt(["run", "--select", "base_table"])  # create the base table
 
     def test_create_semantic_view(self, project):
-        qualified = f"{project.database}.{project.test_schema}.my_semantic_view"
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.my_semantic_view"
 
         # Create the semantic view and assert DDL in logs
         _, logs = run_dbt_and_capture(["--debug", "run", "--select", "my_semantic_view.sql"])
-        assert f"create semantic view {qualified}" in logs.lower()
+        assert f"create or replace semantic view {qualified}" in logs.lower()
 
         # Verify existence via SHOW SEMANTIC VIEWS (preferred for semantic views)
         exists_sql = (
-            f"show semantic views like 'MY_SEMANTIC_VIEW' in schema "
-            f"{project.database}.{project.test_schema}"
+            f"show semantic views like 'MY_SEMANTIC_VIEW' in schema " f"{database}.{schema}"
         )
         rows = project.run_sql(exists_sql, fetch="all")
         assert rows and len(rows) >= 1, "semantic view not found via SHOW SEMANTIC VIEWS"

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -28,6 +28,14 @@ _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL = """
 select * from semantic_view({{ source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
 """
 
+_SCHEMA_YML = """
+version: 2
+
+models:
+  - name: my_semantic_view
+    description: "Semantic view description for persist_docs"
+"""
+
 _SOURCES_YML = """
 version: 2
 sources:
@@ -51,6 +59,19 @@ class TestSemanticViewBasic:
             "table_refer_to_semantic_view.sql": _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL,
             "table_refer_to_raw_semantic_view.sql": _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL,
             "sources.yml": _SOURCES_YML,
+            "schema.yml": _SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "relation": True,
+                    }
+                }
+            }
         }
 
     @pytest.fixture(scope="class", autouse=True)
@@ -130,3 +151,19 @@ class TestSemanticViewBasic:
         semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.raw_semantic_view metrics total_rows);"
         semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
         assert table_select_result[0][0] == semantic_view_select_result[0][0]
+
+    def test_semantic_view_comment(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.my_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(["--debug", "run", "--select", "my_semantic_view.sql"])
+        assert f"comment on semantic view {qualified}" in logs.lower()
+        # Verify existence via SHOW SEMANTIC VIEWS (preferred for semantic views)
+        exists_sql = (
+            f"show semantic views like 'MY_SEMANTIC_VIEW' in schema " f"{database}.{schema}"
+        )
+        rows = project.run_sql(exists_sql, fetch="all")
+        assert "semantic view description for persist_docs" in rows[0][4].lower()


### PR DESCRIPTION
resolves #1260 
dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
dbt-snowflake did not support the new Snowflake "semantic view" relation type, so dbt users could not create or manage semantic views as first-class dbt resources or materializations. There was no materialization, build support, or test coverage for semantic views.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

[Snowflake Semantic Views in DBT](https://docs.google.com/document/d/1F-JGHM6CSGD4Di34eHWeI822EzUMtZAcg4nsDJnBZdQ/edit?usp=sharing)

This pr adds support for "semantic view" as a new materialization in the dbt-snowflake adapter. It introduces the necessary logic, macros, SQL generation, and tests to enable creating, dropping, and renaming semantic views in Snowflake via dbt.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Test
`tests/functional/semantic_view/test_semantic_view_basic.py`

- `test_create_semantic_view`: semantic view model refers to raw table (use `source(<raw_table>)`) and table model (use `ref(<table_model>)`).
- `test_table_refer_to_semantic_view`: table model refers to a semantic view model (use `ref(<semantic_view_model>)`).
- `test_table_refer_to_raw_semantic_view`: table model refers to raw semantic view (use source(<semantic_view>))
- `test_semantic_view_comment`: test description is recorded by `comment on semantic view` command.
- `test_semantic_view_copy_grants_logic`: test copy grants configuration is properly handled.
- `test_semantic_view_with_ca_extension`: test Cortex Analyst Extension query is properly handled in DBT.

```
➜  dbt-snowflake git:(feature/semantic-view/issue-1260) ✗ hatch run unit-tests tests/functional/semantic_view/test_semantic_view_basic.py
======================================================== test session starts ========================================================
platform darwin -- Python 3.11.6, pytest-7.4.4, pluggy-1.6.0 -- /Users/yutliu/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/bin/python
cachedir: .pytest_cache
rootdir: /Users/yutliu/dbt-adapters/dbt-snowflake
configfile: pyproject.toml
plugins: ddtrace-2.3.0, csv-3.0.0, logbook-1.2.0, xdist-3.8.0, dotenv-0.5.2
16 workers [6 items]      
scheduling tests via LoadScheduling

tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_semantic_view 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_comment 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_create_semantic_view 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_raw_semantic_view 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_copy_grants_logic 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_with_ca_extension 
[gw5] [ 16%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_with_ca_extension 
[gw3] [ 33%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_comment 
[gw0] [ 50%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_create_semantic_view 
[gw2] [ 66%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_raw_semantic_view 
[gw4] [ 83%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_copy_grants_logic 
[gw1] [100%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_semantic_view 

========================================================= warnings summary ==========================================================
.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: 17 warnings
  /Users/yutliu/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: DeprecationWarning: 'parser.OptionParser' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState

.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: 17 warnings
  /Users/yutliu/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: DeprecationWarning: 'parser.ParsingState' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState

tests/functional/semantic_view/test_semantic_view_basic.py: 38 warnings
  /Users/yutliu/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/snowflake/connector/__init__.py:54: DeprecationWarning: The 'insecure_mode' connection property is deprecated. Please use 'disable_ocsp_checks' instead
    return SnowflakeConnection(**kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 6 passed, 72 warnings in 15.29s ==================================================
➜  dbt-snowflake git:(feature/semantic-view/issue-1260) ✗ 
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX