### PR TITLE
Make Iceberg timestamp-precision error (091385) actionable

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260709-120000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260709-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Append an actionable hint to the Iceberg timestamp-precision error (091385), pointing
+  users to cast to TIMESTAMP_NTZ(6)/TIMESTAMP_LTZ(6) or use an Iceberg v3 table with nanosecond
+  support enabled
+time: 2026-07-09T12:00:00.000000-07:00
+custom:
+  Author: sfc-gh-nijain
+  Issue: ""

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -401,6 +401,20 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             for regex_pattern, replacement_message in ERROR_REDACTION_PATTERNS.items():
                 msg = re.sub(regex_pattern, replacement_message, msg)
 
+            # Iceberg tables reject timestamp precision greater than microseconds (6) unless the
+            # table is Iceberg format-version 3 with nanosecond timestamp support enabled. The
+            # raw error (091385) does not explain how to resolve it, so append an actionable hint.
+            # This is reactive: it fires only when Snowflake actually rejects the statement, so it
+            # never triggers where nanosecond timestamps are supported (v3 with the feature on).
+            if "091385" in msg:
+                msg = (
+                    f"{msg}\n\n"
+                    "Iceberg supports nanosecond timestamps only on format-version 3 with "
+                    "nanosecond timestamp support enabled. Either cast the column to "
+                    "TIMESTAMP_NTZ(6) / TIMESTAMP_LTZ(6), or use an Iceberg v3 table with "
+                    "nanosecond timestamp support enabled."
+                )
+
             logger.debug("Snowflake query id: {}".format(e.sfqid))
             logger.debug("Snowflake error: {}".format(msg))
 

--- a/dbt-snowflake/tests/functional/iceberg/test_iceberg_timestamp_hint.py
+++ b/dbt-snowflake/tests/functional/iceberg/test_iceberg_timestamp_hint.py
@@ -1,0 +1,36 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+# A v2 Iceberg table (the default) with a TIMESTAMP_NTZ(9) column.
+# Snowflake always rejects nanosecond timestamps on v2 Iceberg tables (error 091385).
+# The adapter should surface an actionable hint alongside the original error.
+_MODEL_ICEBERG_NANO_TIMESTAMP = """
+{{
+  config(
+    materialized="table",
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+  )
+}}
+select '2024-01-01'::TIMESTAMP_NTZ(9) as ts
+"""
+
+
+class TestIcebergTimestampNanosecondHint:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "iceberg_nano_ts.sql": _MODEL_ICEBERG_NANO_TIMESTAMP,
+        }
+
+    def test_timestamp_ntz9_error_includes_actionable_hint(self, project):
+        results = run_dbt(["run"], expect_pass=False)
+        assert len(results) == 1
+        message = results[0].message
+        # original Snowflake error is preserved
+        assert "091385" in message
+        # actionable hint is appended
+        assert "TIMESTAMP_NTZ(6)" in message
+        assert "nanosecond timestamp support enabled" in message

--- a/dbt-snowflake/tests/unit/test_iceberg_timestamp_hint.py
+++ b/dbt-snowflake/tests/unit/test_iceberg_timestamp_hint.py
@@ -1,0 +1,47 @@
+import multiprocessing
+from unittest.mock import Mock
+
+import pytest
+import snowflake.connector.errors
+from dbt_common.exceptions import DbtDatabaseError
+
+from dbt.adapters.snowflake.connections import SnowflakeConnectionManager
+
+
+def _connection_manager():
+    # exception_handler does not touch the profile, so a Mock profile is sufficient.
+    return SnowflakeConnectionManager(Mock(), multiprocessing.get_context("spawn"))
+
+
+def test_exception_handler_appends_iceberg_hint_for_091385():
+    mgr = _connection_manager()
+    err = snowflake.connector.errors.ProgrammingError(
+        msg=(
+            "091385 (42601): Invalid time type scale specified for column 'TS' "
+            "with data type 'TIMESTAMP_NTZ(9)'."
+        )
+    )
+    with pytest.raises(DbtDatabaseError) as excinfo:
+        with mgr.exception_handler("create iceberg table t as (select ...)"):
+            raise err
+
+    message = str(excinfo.value)
+    # the original Snowflake error is preserved
+    assert "091385" in message
+    # and an actionable hint is appended
+    assert "TIMESTAMP_NTZ(6)" in message
+    assert "nanosecond timestamp support enabled" in message
+
+
+def test_exception_handler_does_not_append_hint_for_other_errors():
+    mgr = _connection_manager()
+    err = snowflake.connector.errors.ProgrammingError(
+        msg="002003 (42S02): Object 'X' does not exist or not authorized."
+    )
+    with pytest.raises(DbtDatabaseError) as excinfo:
+        with mgr.exception_handler("select * from x"):
+            raise err
+
+    message = str(excinfo.value)
+    assert "002003" in message
+    assert "TIMESTAMP_NTZ(6)" not in message


### PR DESCRIPTION
When Snowflake rejects a timestamp with precision greater than microseconds (6) on an Iceberg v2 table (error 091385), append a hint to the error: Iceberg needs microsecond precision unless the table is format-version 3 with nanosecond support enabled, and the user can cast to TIMESTAMP_NTZ(6)/TIMESTAMP_LTZ(6).

The hint is reactive: it is appended only when Snowflake actually returns 091385, so it never fires on tables/accounts where nanosecond timestamps are supported.

resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
