### PR TITLE
Add OpenTelemetry span_name parameter to run_hooks macro

### DIFF
--- a/dbt-adapters/.changes/unreleased/Features-20250514-120000.yaml
+++ b/dbt-adapters/.changes/unreleased/Features-20250514-120000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add span_name parameter to run_hooks macro for OpenTelemetry instrumentation
+time: 2025-05-14T12:00:00.000000-07:00
+custom:
+    Author: sfc-gh-vguttha
+    Issue: "11367"

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/hooks.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/hooks.sql
@@ -1,4 +1,4 @@
-{% macro run_hooks(hooks, inside_transaction=True) %}
+{% macro run_hooks(hooks, inside_transaction=True, span_name='run_hooks') %}
   {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
     {% if not inside_transaction and loop.first %}
       {% call statement(auto_begin=inside_transaction) %}

--- a/dbt-snowflake/.changes/unreleased/Features-20250514-120000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250514-120000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add OpenTelemetry span names for pre-hook and post-hook in Snowflake materializations
+time: 2025-05-14T12:00:00.000000-07:00
+custom:
+    Author: sfc-gh-vguttha
+    Issue: "11367"

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.24.4,<2.0",
+    "dbt-adapters>=1.24.5,<2.0",
     # cursor.stats support requires >= 4.2.0 (SNOW-295953)
     "snowflake-connector-python[secure-local-storage]>=4.2.0,<5.0.0",
     "certifi<2025.4.26",

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
@@ -5,7 +5,7 @@
     {% set existing_relation = load_cached_relation(this) %}
     {% set target_relation = this.incorporate(type=this.DynamicTable) %}
 
-    {{ run_hooks(pre_hooks) }}
+    {{ run_hooks(pre_hooks, span_name='pre-hook') }}
 
     {% set build_sql = dynamic_table_get_build_sql(existing_relation, target_relation) %}
 
@@ -22,7 +22,7 @@
         {% endcall %}
     {% endif %}
 
-    {{ run_hooks(post_hooks) }}
+    {{ run_hooks(post_hooks, span_name='post-hook') }}
 
     {% do unset_query_tag(query_tag) %}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -141,7 +141,7 @@
 
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks, span_name='pre-hook') }}
 
   {% if existing_relation is none %}
     {%- call statement('main', language=language) -%}
@@ -212,7 +212,7 @@
 
   {% do drop_relation_if_exists(tmp_relation) %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks, span_name='post-hook') }}
 
   {% set target_relation = target_relation.incorporate(type='table') %}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/table.sql
@@ -18,7 +18,7 @@
 	table_format=catalog_relation.table_format
    ) -%}
 
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks,  span_name='pre-hook') }}
 
   {% if target_relation.needs_to_drop(existing_relation) %}
     {{ drop_relation_if_exists(existing_relation) }}
@@ -28,7 +28,7 @@
       {{ create_table_as(False, target_relation, compiled_code, language) }}
   {%- endcall %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks,  span_name='post-hook') }}
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/view/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/view/create.sql
@@ -54,7 +54,7 @@ eventually be retired in favor of a standardized approach. Changed line:
       type='view') -%}
   {% set grant_config = config.get('grants') %}
 
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks,  span_name='pre-hook') }}
 
   -- If there's a table with the same name and we weren't told to full refresh,
   -- that's an error. If we were told to full refresh, drop it. This behavior differs
@@ -71,7 +71,7 @@ eventually be retired in favor of a standardized approach. Changed line:
   {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks,  span_name='post-hook') }}
 
   {{ return({'relations': [target_relation]}) }}
 


### PR DESCRIPTION
Add span_name kwarg to the global run_hooks macro and pass 'pre-hook' / 'post-hook' from Snowflake materializations so that OpenTelemetry spans created in dbt-core's MacroGenerator can distinguish hook phases.